### PR TITLE
Fix for #25 (Background thread call for bounds)

### DIFF
--- a/HACClusterMapViewController/HACMKMapView.m
+++ b/HACClusterMapViewController/HACMKMapView.m
@@ -38,7 +38,7 @@
 #pragma mark - MKMapViewDelegate
 
 - (void)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated{
-    [[NSOperationQueue new] addOperationWithBlock:^{
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
         double scale = self.bounds.size.width / self.visibleMapRect.size.width;
         NSArray *annotations = [self.coordinateQuadTree clusteredAnnotationsWithinMapRect:mapView.visibleMapRect withZoomScale:scale];
         //TODO: Avoid removing non clustered annotation


### PR DESCRIPTION
Perform the call on the main thread when the region changed, resolves main thread checker warning / error.